### PR TITLE
UPSTREAM: <drop>: switch back to glog

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -78,6 +78,10 @@
 			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
 		},
 		{
+			"ImportPath": "github.com/google/gofuzz",
+			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
+		},
+		{
 			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
 			"Rev": "68f4ded48ba9414dab2ae69b3f0d69971da73aa5"
 		},
@@ -424,10 +428,6 @@
 		{
 			"ImportPath": "k8s.io/gengo/types",
 			"Rev": "75356185a9af8f0464efa792e2e9508d5b4be83c"
-		},
-		{
-			"ImportPath": "k8s.io/klog",
-			"Rev": "b9b56d5dfc9208f60ea747056670942d8b0afdc8"
 		},
 		{
 			"ImportPath": "sigs.k8s.io/structured-merge-diff/schema",

--- a/cmd/openapi-gen/openapi-gen.go
+++ b/cmd/openapi-gen/openapi-gen.go
@@ -28,12 +28,9 @@ import (
 	"k8s.io/kube-openapi/pkg/generators"
 
 	"github.com/spf13/pflag"
-
-	"k8s.io/klog"
 )
 
 func main() {
-	klog.InitFlags(nil)
 	genericArgs, customArgs := generatorargs.NewDefaults()
 
 	genericArgs.AddFlags(pflag.CommandLine)

--- a/pkg/generators/api_linter.go
+++ b/pkg/generators/api_linter.go
@@ -28,7 +28,7 @@ import (
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"github.com/golang/glog"
 )
 
 const apiViolationFileType = "api-violation"
@@ -41,7 +41,7 @@ type apiViolationFile struct {
 
 func (a apiViolationFile) AssembleFile(f *generator.File, path string) error {
 	path = a.unmangledPath
-	klog.V(2).Infof("Assembling file %q", path)
+	glog.V(2).Infof("Assembling file %q", path)
 	if path == "-" {
 		_, err := io.Copy(os.Stdout, &f.Body)
 		return err
@@ -106,7 +106,7 @@ func (v *apiViolationGen) Filename() string {
 }
 
 func (v *apiViolationGen) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
-	klog.V(5).Infof("validating API rules for type %v", t)
+	glog.V(5).Infof("validating API rules for type %v", t)
 	if err := v.linter.validate(t); err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ type APIRule interface {
 // validate runs all API rules on type t and records any API rule violation
 func (l *apiLinter) validate(t *types.Type) error {
 	for _, r := range l.rules {
-		klog.V(5).Infof("validating API rule %v for type %v", r.Name(), t)
+		glog.V(5).Infof("validating API rule %v for type %v", r.Name(), t)
 		fields, err := r.Validate(t)
 		if err != nil {
 			return err

--- a/pkg/generators/config.go
+++ b/pkg/generators/config.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"github.com/golang/glog"
 
 	generatorargs "k8s.io/kube-openapi/cmd/openapi-gen/args"
 )
@@ -54,7 +54,7 @@ func DefaultNameSystem() string {
 func Packages(context *generator.Context, arguments *args.GeneratorArgs) generator.Packages {
 	boilerplate, err := arguments.LoadGoBoilerplate()
 	if err != nil {
-		klog.Fatalf("Failed loading boilerplate: %v", err)
+		glog.Fatalf("Failed loading boilerplate: %v", err)
 	}
 	header := append([]byte(fmt.Sprintf("// +build !%s\n\n", arguments.GeneratedBuildTag)), boilerplate...)
 	header = append(header, []byte(

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/gengo/types"
 	openapi "k8s.io/kube-openapi/pkg/common"
 
-	"k8s.io/klog"
+	"github.com/golang/glog"
 )
 
 // This is the comment tag that carries parameters for open API generation.
@@ -184,7 +184,7 @@ func (g *openAPIGen) Init(c *generator.Context, w io.Writer) error {
 }
 
 func (g *openAPIGen) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
-	klog.V(5).Infof("generating for type %v", t)
+	glog.V(5).Infof("generating for type %v", t)
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
 	err := newOpenAPITypeWriter(sw).generate(t)
 	if err != nil {
@@ -289,7 +289,7 @@ func (g openAPITypeWriter) generateMembers(t *types.Type, required []string) ([]
 			required = append(required, name)
 		}
 		if err = g.generateProperty(&m, t); err != nil {
-			klog.Errorf("Error when generating: %v, %v\n", name, m)
+			glog.Errorf("Error when generating: %v, %v\n", name, m)
 			return required, err
 		}
 	}
@@ -377,7 +377,7 @@ func (g openAPITypeWriter) generateStructExtensions(t *types.Type) error {
 	// Initially, we will only log struct extension errors.
 	if len(errors) > 0 {
 		for _, e := range errors {
-			klog.V(2).Infof("[%s]: %s\n", t.String(), e)
+			glog.V(2).Infof("[%s]: %s\n", t.String(), e)
 		}
 	}
 	// TODO(seans3): Validate struct extensions here.
@@ -393,7 +393,7 @@ func (g openAPITypeWriter) generateMemberExtensions(m *types.Member, parent *typ
 	if len(errors) > 0 {
 		errorPrefix := fmt.Sprintf("[%s] %s:", parent.String(), m.String())
 		for _, e := range errors {
-			klog.V(2).Infof("%s %s\n", errorPrefix, e)
+			glog.V(2).Infof("%s %s\n", errorPrefix, e)
 		}
 	}
 	g.emitExtensions(extensions)


### PR DESCRIPTION
Godep changes here are strange because upstream has broken Godeps. Compare https://github.com/kubernetes/kube-openapi/pull/135