### PR TITLE
UPSTREAM: 312: Allow union without any fields-to-discriminateBy

### DIFF
--- a/pkg/schemaconv/smd.go
+++ b/pkg/schemaconv/smd.go
@@ -214,9 +214,6 @@ func makeUnion(extensions map[string]interface{}) (schema.Union, error) {
 		}
 	}
 
-	if union.Discriminator != nil && len(union.Fields) == 0 {
-		return schema.Union{}, fmt.Errorf("discriminator set to %v, but no fields in union", *union.Discriminator)
-	}
 	return union, nil
 }
 


### PR DESCRIPTION
A union with empty union members is allowed (see https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/1027-api-unions/README.md#empty-union-members). This allows not having union members defined.

See zz_generated.openapi.go https://github.com/kubernetes/kubernetes/blob/master/pkg/generated/openapi/zz_generated.openapi.go for stanza
```
			VendorExtensible: spec.VendorExtensible{
				Extensions: spec.Extensions{
					"x-kubernetes-unions": []interface{}{
						map[string]interface{}{
							"discriminator": "type",
							"fields-to-discriminateBy": map[string]interface{}{
								"localhostProfile": "LocalhostProfile",
							},
						},
					},
				},
			},
```

and compare against the type https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/core/v1/types.go#L3614 to see how the fields-to-discriminateBy is filled in during generation.

-----

**Testing**:

```
$  go test -race -count=1 ./...
?   	k8s.io/kube-openapi/cmd/openapi-gen	[no test files]
?   	k8s.io/kube-openapi/cmd/openapi-gen/args	[no test files]
?   	k8s.io/kube-openapi/cmd/openapi2smd	[no test files]
?   	k8s.io/kube-openapi/pkg/builder3/util	[no test files]
?   	k8s.io/kube-openapi/pkg/common	[no test files]
?   	k8s.io/kube-openapi/pkg/common/restfuladapter	[no test files]
?   	k8s.io/kube-openapi/pkg/util/jsontesting	[no test files]
?   	k8s.io/kube-openapi/pkg/util/proto/testing	[no test files]
?   	k8s.io/kube-openapi/pkg/util/sets	[no test files]
?   	k8s.io/kube-openapi/pkg/validation/strfmt/bson	[no test files]
ok  	k8s.io/kube-openapi/pkg/aggregator	7.622s
ok  	k8s.io/kube-openapi/pkg/builder	0.114s
ok  	k8s.io/kube-openapi/pkg/builder3	0.128s
ok  	k8s.io/kube-openapi/pkg/cached	0.031s
ok  	k8s.io/kube-openapi/pkg/generators	29.875s
ok  	k8s.io/kube-openapi/pkg/generators/rules	0.053s
ok  	k8s.io/kube-openapi/pkg/handler	4.233s
ok  	k8s.io/kube-openapi/pkg/handler3	0.068s
ok  	k8s.io/kube-openapi/pkg/idl	0.029s [no tests to run]
ok  	k8s.io/kube-openapi/pkg/internal	0.028s
ok  	k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json	19.428s
ok  	k8s.io/kube-openapi/pkg/openapiconv	3.887s
ok  	k8s.io/kube-openapi/pkg/schemaconv	9.123s
ok  	k8s.io/kube-openapi/pkg/schemamutation	142.244s
ok  	k8s.io/kube-openapi/pkg/spec3	4.901s
ok  	k8s.io/kube-openapi/pkg/util	0.035s
ok  	k8s.io/kube-openapi/pkg/util/proto	1.906s
ok  	k8s.io/kube-openapi/pkg/util/proto/validation	0.638s
ok  	k8s.io/kube-openapi/pkg/validation/errors	0.031s
ok  	k8s.io/kube-openapi/pkg/validation/spec	119.836s
ok  	k8s.io/kube-openapi/pkg/validation/strfmt	0.099s
ok  	k8s.io/kube-openapi/pkg/validation/validate	0.175s

```
