### PR TITLE
UPSTREAM: 312: Allow union without any fields-to-discriminateBy

### DIFF
--- a/pkg/schemaconv/smd.go
+++ b/pkg/schemaconv/smd.go
@@ -214,9 +214,6 @@ func makeUnion(extensions map[string]interface{}) (schema.Union, error) {
 		}
 	}
 
-	if union.Discriminator != nil && len(union.Fields) == 0 {
-		return schema.Union{}, fmt.Errorf("discriminator set to %v, but no fields in union", *union.Discriminator)
-	}
 	return union, nil
 }
 


### PR DESCRIPTION
A union with empty union members is allowed (see https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/1027-api-unions/README.md#empty-union-members). This allows not having union members defined.

See zz_generated.openapi.go https://github.com/kubernetes/kubernetes/blob/master/pkg/generated/openapi/zz_generated.openapi.go for stanza
```
			VendorExtensible: spec.VendorExtensible{
				Extensions: spec.Extensions{
					"x-kubernetes-unions": []interface{}{
						map[string]interface{}{
							"discriminator": "type",
							"fields-to-discriminateBy": map[string]interface{}{
								"localhostProfile": "LocalhostProfile",
							},
						},
					},
				},
			},
```

and compare against the type https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/core/v1/types.go#L3614 to see how the fields-to-discriminateBy is filled in during generation.